### PR TITLE
Changes to README based on a test install:

### DIFF
--- a/MMDVM.README
+++ b/MMDVM.README
@@ -21,7 +21,8 @@ your start. On a Raspberry Pi, you can do all of this with the configureation me
 3)  cd into the MMDVMHost directory and compile: make
     If you're system has multiple processors, use: make -jx
     where x is the number of processors on you system.
-    To tell how many processors you have: cat /cpu/info | grep processor | wc -l
+    To tell how many processors you have on Raspbian Stretch:
+    cat /proc/cpuinfo | grep processor | wc -l
 
 4)  Copy the ini file template: cp MMDVM.ini MMDVM.qn
 
@@ -58,11 +59,14 @@ your start. On a Raspberry Pi, you can do all of this with the configureation me
 13) You need a gwys.txt file for all the systems to which you may wish to link.
     If you want to be able to link to repeaters: ./get_gwy_list.sh
     If you are only interested in linking to reflectors: ./reflist.sh
-    This will download and format your gwys.txt file. If you find you can no
-    longer connect to a system, it may be because its IP address has changed. You
-    can execute either script again, copy it to /usr/local/etc, and then either
-    reboot you system, or put "       L" in your URField and key
-    your radio, or: sudo systemctl restart qnlink
+    This will download and format your gwys.txt file.
+    If the reflector(s) or repeater(s) you use most often are not present in the
+    gwys.txt file, you can add them manually, using the same syntax as the existing
+    entries, at the end of the file.
+    If you find you can no longer connect to a system, it may be because its IP
+    address has changed. You can execute either script again, copy it to
+    /usr/local/etc, and then either reboot you system, or put "       L" in your
+    URField and key your radio, or: sudo systemctl restart qnlink
 
 14) We have a gwys.txt file and a qn.cfg in the build directory, so we are ready
 	to install and start the three QnetGateway services: sudo make install


### PR DESCRIPTION
cat /proc/cpuinfo is required on Raspbian Stretch
included note on updating gwys.txt manually